### PR TITLE
add negative test && fix panic

### DIFF
--- a/repeat_options.go
+++ b/repeat_options.go
@@ -79,7 +79,10 @@ func (a *analyzer) getVariadicArgs(pass *analysis.Pass, n *ast.CallExpr) []ast.E
 		return nil
 	}
 
-	fnType := pass.TypesInfo.TypeOf(n.Fun).Underlying()
+	fnType := pass.TypesInfo.TypeOf(n.Fun)
+	if _, ok := fnType.(*types.Named); ok {
+		return nil
+	}
 
 	fnSign, ok := fnType.(*types.Signature)
 	if !ok {

--- a/testdata/src/repeatoptions/negative.go
+++ b/testdata/src/repeatoptions/negative.go
@@ -1,0 +1,18 @@
+package repeatoptions
+
+type NewExportFunc func(arg1, arg2 any, opts ...ExportOpt) error
+
+func export(_, _ any, _ ...ExportOpt) error {
+	return nil
+}
+
+func Negative1() NewExportFunc {
+	// just a type convert
+	return NewExportFunc(export)
+}
+
+func Negative2() {
+	f := Negative1()
+
+	_ = f(nil, nil)
+}


### PR DESCRIPTION
see https://github.com/alingse/copyandpaste/actions/runs/13923508344/job/38962072135

```
panic: runtime error: slice bounds out of range [6:1]
goroutine 13958 [running]:
github.com/alingse/copyandpaste.(*analyzer).getVariadicArgs(0x0?, 0x1?, 0xc00f606ec0)
	/home/runner/work/copyandpaste/copyandpaste/repeat_options.go:93 +0xf1
github.com/alingse/copyandpaste.(*analyzer).repeatOptionsCallExpr(0x9ef380, 0xc014ffd930, 0xc00a146180?)
	/home/runner/work/copyandpaste/copyandpaste/repeat_options.go:21 +0x25
github.com/alingse/copyandpaste.(*analyzer).checkRepeatOptions(0x9ef380?, 0xc014ffd930?, {0x7f3a10?, 0xc00f606ec0?})
	/home/runner/work/copyandpaste/copyandpaste/repeat_options.go:14 +0x5c
github.com/alingse/copyandpaste.(*analyzer).run.(*analyzer).visit.func1({0x7f3a10, 0xc00f606ec0})
	/home/runner/work/copyandpaste/copyandpaste/linter.go:66 +0x3b
golang.org/x/tools/go/ast/inspector.(*Inspector).Preorder(0xc01560a498, {0x0?, 0x9c7d00?, 0xc014bfcd60?}, 0xc00f50dc68)
	/home/runner/go/pkg/mod/golang.org/x/tools@v0.16.1/go/ast/inspector/inspector.go:82 +0x8f
github.com/alingse/copyandpaste.(*analyzer).run(0x9ef380, 0xc014ffd930)
	/home/runner/work/copyandpaste/copyandpaste/linter.go:59 +0x7d
golang.org/x/tools/go/analysis/internal/checker.(*action).execOnce(0xc0[139](https://github.com/alingse/copyandpaste/actions/runs/13923508344/job/38962072135#step:3:144)44f00)
	/home/runner/go/pkg/mod/golang.org/x/tools@v0.16.1/go/analysis/internal/checker/checker.go:775 +0x9bf
sync.(*Once).doSlow(0xc00924ab00?, 0xc0082475d8?)
	/opt/hostedtoolcache/go/1.23.0/x64/src/sync/once.go:76 +0xb4
```